### PR TITLE
Rebrand as terradiff

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,13 @@
 terradiff
 =========
 
-.. image:: https://circleci.com/gh/jml/mass-driver/tree/master.svg?style=svg
-    :target: https://circleci.com/gh/jml/mass-driver/tree/master
+.. image:: https://circleci.com/gh/jml/terradiff/tree/master.svg?style=svg
+    :target: https://circleci.com/gh/jml/terradiff/tree/master
+    :alt: CircleCI build of master
+
+.. image:: https://quay.io/repository/jml0/terradiff/status
+    :target: https://quay.io/repository/jml0/terradiff
+    :alt: Docker Repository on Quay
 
 Get told when reality no longer matches your Terraform configuration.
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,6 +1,6 @@
 name: terradiff
 version: 0.1.0.0
-homepage: https://github.com/jml/mass-driver#readme
+homepage: https://github.com/jml/terradiff#readme
 license: AGPL
 author: Jonathan Lange
 maintainer: jml@mumak.net
@@ -16,7 +16,7 @@ category: Web
 # To avoid duplicated efforts in documentation and dealing with the
 # complications of embedding Haddock markup inside cabal files, it is
 # common to point users to the README file.
-description: Please see the README on GitHub at <https://github.com/jml/mass-driver#readme>
+description: Please see the README on GitHub at <https://github.com/jml/terradiff#readme>
 
 ghc-options: -Wall -Werror
 default-extensions:

--- a/src/Terradiff/API.hs
+++ b/src/Terradiff/API.hs
@@ -63,7 +63,7 @@ flags =
     parseURI = note "Must be an absolute URL" . URI.parseAbsoluteURI
 
     upstreamURL = fromMaybe (panic ("Invalid source code URI in source code: " <> toS upstreamURL')) (URI.parseAbsoluteURI upstreamURL')
-    upstreamURL' = "https://github.com/jml/mass-driver"
+    upstreamURL' = "https://github.com/jml/terradiff"
 
 -- | Configuration from the whole application, used in various handlers.
 data Config

--- a/terradiff-base/Dockerfile
+++ b/terradiff-base/Dockerfile
@@ -1,1 +1,2 @@
 FROM ubuntu:18.04
+RUN apt-get update && apt-get -y dist-upgrade


### PR DESCRIPTION
The GitHub repository has moved, so should our links.

Bonus fixes:
- more accessible links to CircleCI shield
- link to quay.io shield 
- more secure image