### PR TITLE
Run `terraform init` on each diff

### DIFF
--- a/src/Terradiff/API.hs
+++ b/src/Terradiff/API.hs
@@ -120,9 +120,10 @@ newtype TerraformPlan = TerraformPlan Terraform.Plan deriving (Eq, Show)
 
 instance ToHtml TerraformPlan where
   toHtmlRaw = toHtml
-  toHtml (TerraformPlan Terraform.Plan{Terraform.refreshResult, Terraform.planResult}) =
+  toHtml (TerraformPlan Terraform.Plan{Terraform.initResult, Terraform.refreshResult, Terraform.planResult}) =
     div_ [class_ "container"] $ do
       h1_ "terraform plan"
+      processToHtml initResult
       processToHtml refreshResult
       processToHtml planResult
     where


### PR DESCRIPTION
We're seeing "uninitialized" errors when running this on Kubernetes with
git-sync, despite the fact that we're running `terraform init` at the start of
the process.

The cause is not well understood. We don't have logs (and we don't know why we
don't have logs!). However, on reflection, running `init` before each diff is
the only way to be sure that `init` has been run.