### PR TITLE
Better UI for terradiff

### DIFF
--- a/src/Terradiff.hs
+++ b/src/Terradiff.hs
@@ -74,7 +74,7 @@ run Config{serverConfig, apiConfig, terraformConfig, pollInterval} = do
                 "output:\n" <> Terraform.processOutput initResult <> "\n" <>
                 "error:\n" <> Terraform.processError initResult <> "\n"))
     _ ->
-      Poll.runWhilePolling (Terraform.diff tfConfig) (Duration.toDiffTime pollInterval)
+      Poll.runWhilePolling (runExceptT $ Terraform.diff tfConfig) (Duration.toDiffTime pollInterval)
         (JmlSvc.run "terradiff" serverConfig . API.app apiConfig)
 
 someFunc :: Int -> Int -> Int

--- a/src/Terradiff.hs
+++ b/src/Terradiff.hs
@@ -75,7 +75,7 @@ run Config{serverConfig, apiConfig, terraformConfig, pollInterval} = do
                 "error:\n" <> Terraform.processError initResult <> "\n"))
     _ ->
       Poll.runWhilePolling (runExceptT $ Terraform.diff tfConfig) (Duration.toDiffTime pollInterval)
-        (JmlSvc.run "terradiff" serverConfig . API.app apiConfig)
+        (JmlSvc.run "terradiff" serverConfig . API.app apiConfig (Terraform.terraformPath tfConfig))
 
 someFunc :: Int -> Int -> Int
 someFunc x y = x + y

--- a/src/Terradiff/API.hs
+++ b/src/Terradiff/API.hs
@@ -15,14 +15,15 @@ module Terradiff.API
 import Protolude
 
 import Lucid
-import Network.URI (URI(..))
+import Network.URI (URI(..), relativeTo)
 import qualified Network.URI as URI
 import qualified Options.Applicative as Opt
 import qualified Servant
 import Servant.API (Get, (:<|>)(..), (:>), Raw)
 import Servant.HTML.Lucid (HTML)
 import Servant.Server (hoistServer)
-import Servant.Utils.StaticFiles (serveDirectoryWebApp)
+import Servant.Utils.Links (Link, linkURI, safeLink)
+import Servant.Utils.StaticFiles (serveDirectoryWebApp, serveDirectoryFileServer)
 
 import Terradiff.Poll (Poll)
 import qualified Terradiff.Poll as Poll
@@ -69,38 +70,46 @@ flags =
 data Config
   = Config
   { apiConfig :: APIConfig
+  , terraformConfigPath :: FilePath
   , planPoller :: Poll PlanResult
   }
 
 -- | terradiff API definition.
 type API
-  = StaticResources
-    :<|> Get '[HTML] (Page TerraformPlan)
+  = TerraformConfig
+    :<|> StaticResources
+    :<|> DiffPage
+
+-- | The diff itself!
+type DiffPage = Get '[HTML] (Page TerraformPlan)
 
 -- | Where all of our stylesheets live.
 type StaticResources = "static" :> Raw
+
+-- | The actual Terraform configuration files.
+type TerraformConfig = "terraform-config" :> Raw
 
 -- | Value-level representation of 'API'.
 api :: Proxy API
 api = Proxy
 
 -- | WAI application that implements 'API'.
-app :: APIConfig -> Poll PlanResult -> Servant.Application
-app apiConfig terraformConfig = Servant.serve api (server (Config apiConfig terraformConfig))
+app :: APIConfig -> FilePath -> Poll PlanResult -> Servant.Application
+app apiConfig terraformConfigPath terraformConfig = Servant.serve api (server (Config apiConfig terraformConfigPath terraformConfig))
 
 -- | Server-side implementation of 'API'.
 server :: Config -> Servant.Server API
 server config = hoistServer api (`runReaderT` config)
-  ( serveDirectoryWebApp (staticDir (apiConfig config))
+  ( serveDirectoryFileServer (terraformConfigPath config)
+    :<|> serveDirectoryWebApp (staticDir (apiConfig config))
     :<|> viewTerraformPlan
   )
-
 
 viewTerraformPlan :: ReaderT Config Servant.Handler (Page TerraformPlan)
 viewTerraformPlan = do
   Config{planPoller} <- ask
   plan <- liftIO (atomically (Poll.waitForResult planPoller))
-  makePage "terraform plan" (TerraformPlan plan)
+  makePage "terradiff" (safeLink api (Proxy @DiffPage)) (TerraformPlan plan)
 
 -- | Results of running @terraform plan@. This is what we get out of the poller.
 type PlanResult = Either Terraform.Error (Maybe Terraform.Diff)
@@ -111,14 +120,21 @@ newtype TerraformPlan = TerraformPlan PlanResult deriving (Eq, Show)
 instance ToHtml TerraformPlan where
   toHtmlRaw = toHtml
   toHtml (TerraformPlan planResult) =
-    div_ [class_ "container"] $ do
-      h1_ "terraform plan"
+    div_ [class_ "container mt-2"] $ do
+      h1_ "terradiff"
       case planResult of
-        Left (Terraform.ProcessError processResult) -> processToHtml processResult
+        Left (Terraform.ProcessError processResult) -> do
+          div_ [class_ "alert alert-danger", role_ "alert"] $ do
+            "There was an error running "
+            code_ "terraform"
+          processToHtml processResult
         Right (Just (Terraform.Diff diffOutput)) -> do
-          h2_ "diff!"
-          pre_ (toHtml diffOutput)
-        Right Nothing -> h2_ "No diff"
+          div_ [class_ "alert alert-warning", role_ "alert"]
+            "Configuration and environment do not match"
+          pre_ [class_ "ml-2"] (code_ (toHtml diffOutput))
+        Right Nothing ->
+          div_ [class_ "alert alert-success", role_ "alert"]
+            "Configuration and environment are up-to-date"
     where
       processToHtml :: Monad m => Terraform.ProcessResult -> HtmlT m ()
       processToHtml Terraform.ProcessResult { Terraform.processTitle
@@ -126,35 +142,53 @@ instance ToHtml TerraformPlan where
                                             , Terraform.processOutput
                                             , Terraform.processError
                                             } = do
-          h2_ (toHtml processTitle)
+          h2_ "Details"
           dl_ $ do
+            dt_ "Command"
+            dd_ $ code_ (toHtml processTitle)
             dt_ "Exit code"
             dd_ (toHtml (show processExitCode :: Text))
             dt_ "stdout"
-            dd_ $ pre_ (toHtml processOutput)
+            dd_ $ pre_ [class_ "ml-2"] (toHtml processOutput)
             dt_ "stderr"
-            dd_ $ pre_ (toHtml processError)
+            dd_ $ pre_ [class_ "ml-2"] (toHtml processError)
 
 -- | A standard HTML page in the terradiff app.
 data Page a
   = Page
   { config :: APIConfig -- ^ The configuration for the app
   , title :: Text  -- ^ The title of the page
+  , currentURI :: URI   -- ^ URI of the page the user is currently viewing
   , content :: a  -- ^ The main content
   } deriving (Eq, Show)
 
 instance ToHtml a => ToHtml (Page a) where
   toHtmlRaw = toHtml
-  toHtml Page{config, title, content} =
+  toHtml Page{config, title, currentURI, content} =
     doctypehtml_ $ do
       head_ $ do
         meta_ [name_ "viewport", content_ "width=device-width, initial-scale=1, shrink-to-fit=no"]
         link_ [rel_ "stylesheet", staticLink config "style.css"]
         title_ (toHtml title)
       body_ $ do
+        nav_ [class_ "navbar navbar-expand-lg navbar-dark bg-dark"] $
+          div_ [class_ "collapse navbar-collapse"] $
+            ul_ [class_ "navbar-nav mr-auto"] $ do
+              let baseURL = externalURL config
+              forM_ navLinks $ \(link', label) ->
+                let destURL = safeHref_ baseURL link'
+                in if linkURI link' == currentURI
+                   then
+                     li_ [class_ "nav-item active"] $
+                     a_ [class_ "nav-link", destURL] $ do
+                       label
+                       " "
+                       span_ [class_ "sr-only"] "(current)"
+                   else li_ [class_ "nav-item"] $ a_ [class_ "nav-link", destURL] label
         main_ [role_ "main"] (toHtml content)
-        footer_ [class_ "container"] $
-          p_ $ do
+        footer_ [class_ "container"] $ do
+          hr_ empty
+          p_ [class_ "font-weight-light"] $ do
             "Copyright © Jonathan M. Lange 2018. "
             "Made available under the "
             a_ [href_ "https://www.gnu.org/licenses/agpl.html"] "AGPLv3 license"
@@ -162,6 +196,16 @@ instance ToHtml a => ToHtml (Page a) where
             "Source code at "
             a_ [uriHref_ (sourceURL config)] (toHtml (show @URI @Text (sourceURL config)))
             "."
+    where
+      navLinks =
+        [ (safeLink api (Proxy @DiffPage), "Diff")
+        , (safeLink api (Proxy @TerraformConfig), "Configuration")
+        ]
+
+-- | Generate an href= attribute that links to something in the API, relative
+-- to the external URL.
+safeHref_ :: URI -> Link -> Attribute
+safeHref_ externalURL link' = href_ (show (linkURI link' `relativeTo` externalURL))
 
 -- | Link to a resource within our static resources.
 --
@@ -178,7 +222,7 @@ uriHref_ :: URI -> Attribute
 uriHref_ uri = href_ (show uri)
 
 -- | Make a standard HTML page in the compare revisions app.
-makePage :: MonadReader Config m => Text -> body -> m (Page body)
-makePage title body = do
+makePage :: MonadReader Config m => Text -> Link -> body -> m (Page body)
+makePage title currentLink body = do
   Config{apiConfig} <- ask
-  pure (Page apiConfig title body)
+  pure (Page apiConfig title (linkURI currentLink) body)


### PR DESCRIPTION
- Navbar
- Link to actual configuration (useful for debugging)
- Better styling for results
- Only show `plan` output when there's a diff
- Otherwise, only show output when there's an error

Link to configuration is missing a trailing slash. Will fix that later, I guess.