### PR TITLE
Better visibility on process failure

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -37,6 +37,7 @@ library:
     - clock
     - jml-web-service
     - lucid
+    - monad-logger
     - network-uri
     - optparse-applicative
     - process

--- a/src/Terradiff/Terraform.hs
+++ b/src/Terradiff/Terraform.hs
@@ -28,10 +28,6 @@ module Terradiff.Terraform
   , Diff(..)
   , Error(..)
   , Terradiff.Terraform.diff
-  -- * Actually using Terraform.
-  , init
-  , refresh
-  , plan
   ) where
 
 import Protolude

--- a/src/Terradiff/Terraform.hs
+++ b/src/Terradiff/Terraform.hs
@@ -207,13 +207,17 @@ diff terraformConfig = do
   case processExitCode planResult of
     ExitSuccess -> pure Nothing
     ExitFailure 2 -> pure (Just (Diff (processOutput planResult)))
-    ExitFailure _ -> throwError (ProcessError planResult)
+    ExitFailure _ -> gotError planResult
   where
     exitGauge ExitSuccess = 0.0
     exitGauge (ExitFailure n) = fromIntegral n
 
     handleError (ProcessResult _ ExitSuccess out _) = pure out
-    handleError failed = throwError (ProcessError failed)
+    handleError failed = gotError failed
+
+    gotError failed = do
+      logError $ "Process failed: " <> Protolude.show failed
+      throwError (ProcessError failed)
 
 -- | The diff output from @terraform plan@. Generate this with 'diff'.
 newtype Diff = Diff ByteString deriving (Eq, Show)

--- a/stack.yaml
+++ b/stack.yaml
@@ -20,6 +20,7 @@ extra-deps:
   - base-compat-0.10.1
   - exceptions-0.10.0
   - http-api-data-0.3.8.1
+  - monad-logger-0.3.29
   - servant-0.14
   - servant-lucid-0.8.1
   - servant-server-0.14


### PR DESCRIPTION
- show all process results when debug logging enabled
- log failed processes as 'error'

Note that this is a bit suboptimal, as terraform is expected to fail with lock errors. We don't have a good way of filtering them out at present.