### PR TITLE
Include output & error, rather than showing them

### DIFF
--- a/src/Terradiff/Terraform.hs
+++ b/src/Terradiff/Terraform.hs
@@ -245,8 +245,8 @@ formatProcessResult :: ProcessResult -> Text
 formatProcessResult ProcessResult{processTitle, processInfo, processExitCode, processOutput, processError} =
   Protolude.show processTitle <> " " <> status <> ": " <> Protolude.show processExitCode <> "\n" <>
   "Command: " <> command <> "\n" <>
-  "Output:\n----\n" <> Protolude.show processOutput <> "----\n" <>
-  "Error:\n----\n" <> Protolude.show processError <> "----\n"
+  "Output:\n----\n" <> toS processOutput <> "----\n" <>
+  "Error:\n----\n" <> toS processError <> "----\n"
   where
     status = case processExitCode of
                ExitSuccess -> "succeeded"


### PR DESCRIPTION
This means we'll get literal newlines, rather than `\n` everywhere.